### PR TITLE
Fix InvalidCastException on startup on non-English regional settings

### DIFF
--- a/Language Pad/LanguagePadCommon.vb
+++ b/Language Pad/LanguagePadCommon.vb
@@ -8,7 +8,7 @@ Module LanguagePadCommon
     Public FirstTabUpdate As Boolean = False
     Public Initialized As Boolean = False
     Public DecimalSep As String() = {" ", "'", ",", ".", "·", " ", " ", "˙", "٫", "٬", "⎖"}
-    Public CurrentVersion As Decimal = (Application.ProductVersion.Split(DecimalSep, StringSplitOptions.RemoveEmptyEntries).GetValue(0) & "." & Application.ProductVersion.Split(DecimalSep, StringSplitOptions.RemoveEmptyEntries).GetValue(1))
+    Public CurrentVersion As Decimal = Decimal.Parse((Application.ProductVersion.Split(DecimalSep, StringSplitOptions.RemoveEmptyEntries).GetValue(0) & "." & Application.ProductVersion.Split(DecimalSep, StringSplitOptions.RemoveEmptyEntries).GetValue(1)), CultureInfo.InvariantCulture)
     Public LangPadVersion As String = "Language Pad " & (Application.ProductVersion.Split(DecimalSep, StringSplitOptions.RemoveEmptyEntries).GetValue(0) & If(Application.ProductVersion.Split(DecimalSep, StringSplitOptions.RemoveEmptyEntries).GetValue(1) = "0", "", "." & Application.ProductVersion.Split(DecimalSep, StringSplitOptions.RemoveEmptyEntries).GetValue(1)))
     Public Function GetTextFromRTF(ByVal RTF As String)
         Dim rtb As New RichTextBox


### PR DESCRIPTION
Exception `System.InvalidCastException` with a message of
`Conversion from string "8.2" to type 'Decimal' is not valid.` was
raised when running the application on non-English regional settings
(when character different than . (dot) is a numerical separator).

Explicit usage of InvariantCulture when converting string to decimal
is not based on the regional separator, so it's always working.